### PR TITLE
valid_hostname - check helo hostname for valid ascii string

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "haraka-test-fixtures": "1.3.9"
   },
   "dependencies": {
+    "haraka-dsn": "^1.1.0",
     "haraka-net-utils": "^1.7.2",
     "haraka-tld": "^1.2.3",
     "haraka-utils": "^1.1.4"


### PR DESCRIPTION
Changes proposed in this pull request:

- valid_hostname - also check HELO host whether it is a valid ascii string, and if not then DENY and close connection
- create a valid DSN response for such an error

Fixes #6 
